### PR TITLE
Quick fix for client rev 920-1

### DIFF
--- a/src/main/java/RS3NXTRefactorer.java
+++ b/src/main/java/RS3NXTRefactorer.java
@@ -69,7 +69,7 @@ public class RS3NXTRefactorer extends GhidraScript {
 	private int getClientVersion() {
 		MemoryBlock block = getMemoryBlock(".rdata");
 		List<FoundString> strings = findStrings(new AddressSet(block.getStart(), block.getEnd()), 8, 1, true, false);
-		strings = strings.stream().filter(string -> string.getString(currentProgram.getMemory()).equals("Build: %d:%d/%s")).collect(Collectors.toList());
+		strings = strings.stream().filter(string -> string.getString(currentProgram.getMemory()).equals("Client Version: %i-%i")).collect(Collectors.toList());
 		if (strings.size() != 1) {
 			throw new IllegalStateException("Failed to get client version: " + strings);
 		}


### PR DESCRIPTION
Version string changed to print out in the client terminal as a string, compared to previous versions that had it locked on the lower right hand side.

920 and above uses: "Client Version: %i-%i"
919 and below uses: "Build: %d:%d/%s"